### PR TITLE
feat: auto-detect Code Mode availability

### DIFF
--- a/src/ai/anthropic.ts
+++ b/src/ai/anthropic.ts
@@ -9,7 +9,11 @@ import type { MCPTool } from "../protocol/messages.js";
 import type { MCPContext } from "../config/types.js";
 import { executeToolWithToken, getProviderTokens, ensureClientConnected, type AIToolsOptions } from "./utils.js";
 import { createTriggerTools } from "./trigger-tools.js";
-import { buildCodeModeTool, CODE_MODE_TOOL_NAME } from "../code-mode/tool-builder.js";
+import {
+  buildCodeModeTool,
+  canUseCodeMode,
+  CODE_MODE_TOOL_NAME,
+} from "../code-mode/tool-builder.js";
 import { zodToJsonSchema } from "zod-to-json-schema";
 import type Anthropic from "@anthropic-ai/sdk";
 
@@ -37,12 +41,12 @@ export interface AnthropicToolsOptions extends AIToolsOptions {
   /**
    * How to expose MCP tools to the model.
    *
-   * - `'code'` (default): Returns a single `execute_code` tool backed by a
+   * - `'code'`: Returns a single `execute_code` tool backed by a
    *   Vercel Sandbox. The model writes TypeScript that calls the typed
    *   `client.<integration>.<method>()` API and chains operations in one round-trip.
    * - `'tools'`: Legacy behavior — one Anthropic tool per MCP tool.
    *
-   * @default 'code'
+   * @default auto-detects `'code'` when sandbox + public URL are available, otherwise `'tools'`
    */
   mode?: 'code' | 'tools';
 }
@@ -268,9 +272,12 @@ export async function getAnthropicTools(
   // Use getEnabledToolsAsync to ensure schemas are always populated
   // This fetches from server if not connected, otherwise uses cached tools
   const mcpTools = await client.getEnabledToolsAsync();
-  const mode = options?.mode ?? 'code';
+  const effectiveMode: 'code' | 'tools' =
+    options?.mode !== undefined
+      ? options.mode
+      : ((await canUseCodeMode(client)) ? 'code' : 'tools');
 
-  const anthropicTools: AnthropicTool[] = mode === 'code'
+  const anthropicTools: AnthropicTool[] = effectiveMode === 'code'
     ? (() => {
         const codeTool = buildCodeModeTool(client, {
           tools: mcpTools,
@@ -401,4 +408,3 @@ export async function handleAnthropicMessage(
     },
   ];
 }
-

--- a/src/ai/google.ts
+++ b/src/ai/google.ts
@@ -9,7 +9,11 @@ import type { MCPTool } from "../protocol/messages.js";
 import type { MCPContext } from "../config/types.js";
 import { executeToolWithToken, getProviderTokens, ensureClientConnected, type AIToolsOptions } from "./utils.js";
 import { createTriggerTools } from "./trigger-tools.js";
-import { buildCodeModeTool, CODE_MODE_TOOL_NAME } from "../code-mode/tool-builder.js";
+import {
+  buildCodeModeTool,
+  canUseCodeMode,
+  CODE_MODE_TOOL_NAME,
+} from "../code-mode/tool-builder.js";
 import { zodToJsonSchema } from "zod-to-json-schema";
 
 // Type-only imports from @google/genai
@@ -56,12 +60,12 @@ export interface GoogleToolsOptions extends AIToolsOptions {
   /**
    * How to expose MCP tools to the model.
    *
-   * - `'code'` (default): Returns a single `execute_code` tool backed by a
+   * - `'code'`: Returns a single `execute_code` tool backed by a
    *   Vercel Sandbox. The model writes TypeScript that calls the typed
    *   `client.<integration>.<method>()` API and chains operations in one round-trip.
    * - `'tools'`: Legacy behavior — one Google FunctionDeclaration per MCP tool.
    *
-   * @default 'code'
+   * @default auto-detects `'code'` when sandbox + public URL are available, otherwise `'tools'`
    */
   mode?: 'code' | 'tools';
 }
@@ -371,10 +375,13 @@ export async function getGoogleTools(
   // Use getEnabledToolsAsync to ensure schemas are always populated
   // This fetches from server if not connected, otherwise uses cached tools
   const mcpTools = await client.getEnabledToolsAsync();
-  const mode = options?.mode ?? 'code';
+  const effectiveMode: 'code' | 'tools' =
+    options?.mode !== undefined
+      ? options.mode
+      : ((await canUseCodeMode(client)) ? 'code' : 'tools');
 
   let googleTools: GoogleTool[];
-  if (mode === 'code') {
+  if (effectiveMode === 'code') {
     const TypeEnum = await getGoogleType();
     const codeTool = buildCodeModeTool(client, {
       tools: mcpTools,
@@ -499,4 +506,3 @@ function convertJsonSchemaToGoogleSchema(jsonSchema: any, TypeEnum: typeof Type)
   
   return result;
 }
-

--- a/src/ai/openai.ts
+++ b/src/ai/openai.ts
@@ -9,7 +9,11 @@ import type { MCPTool } from "../protocol/messages.js";
 import type { MCPContext } from "../config/types.js";
 import { executeToolWithToken, getProviderTokens, ensureClientConnected, type AIToolsOptions } from "./utils.js";
 import { createTriggerTools } from "./trigger-tools.js";
-import { buildCodeModeTool, CODE_MODE_TOOL_NAME } from "../code-mode/tool-builder.js";
+import {
+  buildCodeModeTool,
+  canUseCodeMode,
+  CODE_MODE_TOOL_NAME,
+} from "../code-mode/tool-builder.js";
 import { zodToJsonSchema } from "zod-to-json-schema";
 import type { OpenAI } from "openai";
 
@@ -41,12 +45,12 @@ export interface OpenAIToolsOptions extends AIToolsOptions {
   /**
    * How to expose MCP tools to the model.
    *
-   * - `'code'` (default): Returns a single `execute_code` tool backed by a
+   * - `'code'`: Returns a single `execute_code` tool backed by a
    *   Vercel Sandbox. The model writes TypeScript that calls the typed
    *   `client.<integration>.<method>()` API and chains operations in one round-trip.
    * - `'tools'`: Legacy behavior — one OpenAI function tool per MCP tool.
    *
-   * @default 'code'
+   * @default auto-detects `'code'` when sandbox + public URL are available, otherwise `'tools'`
    */
   mode?: 'code' | 'tools';
 }
@@ -143,9 +147,12 @@ export async function getOpenAITools(
   // Use getEnabledToolsAsync to ensure schemas are always populated
   // This fetches from server if not connected, otherwise uses cached tools
   const mcpTools = await client.getEnabledToolsAsync();
-  const mode = options?.mode ?? 'code';
+  const effectiveMode: 'code' | 'tools' =
+    options?.mode !== undefined
+      ? options.mode
+      : ((await canUseCodeMode(client)) ? 'code' : 'tools');
 
-  const openaiTools: OpenAITool[] = mode === 'code'
+  const openaiTools: OpenAITool[] = effectiveMode === 'code'
     ? (() => {
         const codeTool = buildCodeModeTool(client, {
           tools: mcpTools,
@@ -383,4 +390,3 @@ export async function handleOpenAIResponse(
 
   return handleOpenAIToolCalls(client, functionCalls, finalOptions);
 }
-

--- a/src/ai/vercel-ai.ts
+++ b/src/ai/vercel-ai.ts
@@ -16,7 +16,11 @@ import {
   type AIToolsOptions
 } from "./utils.js";
 import { createTriggerTools } from "./trigger-tools.js";
-import { buildCodeModeTool, CODE_MODE_TOOL_NAME } from "../code-mode/tool-builder.js";
+import {
+  buildCodeModeTool,
+  canUseCodeMode,
+  CODE_MODE_TOOL_NAME,
+} from "../code-mode/tool-builder.js";
 
 /**
  * Tool definition compatible with Vercel AI SDK v5
@@ -37,14 +41,14 @@ export interface VercelAIToolsOptions extends AIToolsOptions {
   /**
    * How to expose MCP tools to the model.
    *
-   * - `'code'` (default): Returns a single `execute_code` tool. The model writes
+   * - `'code'`: Returns a single `execute_code` tool. The model writes
    *   a TypeScript snippet that calls the typed `client.<integration>.<method>()`
    *   API; the snippet runs in an isolated Vercel Sandbox and calls back into
    *   `/api/integrate/mcp`. Chains multiple operations in one round-trip.
    * - `'tools'`: Legacy behavior — returns one AI tool per MCP tool. Use this
    *   if you can't run `@vercel/sandbox` or need the model to see every tool.
    *
-   * @default 'code'
+   * @default auto-detects `'code'` when sandbox + public URL are available, otherwise `'tools'`
    */
   mode?: 'code' | 'tools';
 }
@@ -155,9 +159,12 @@ export async function getVercelAITools(
   const mcpTools = await client.getEnabledToolsAsync();
   const vercelTools: Record<string, any> = {};
 
-  const mode = options?.mode ?? 'code';
+  const effectiveMode: 'code' | 'tools' =
+    options?.mode !== undefined
+      ? options.mode
+      : ((await canUseCodeMode(client)) ? 'code' : 'tools');
 
-  if (mode === 'code') {
+  if (effectiveMode === 'code') {
     const codeTool = buildCodeModeTool(client, {
       tools: mcpTools,
       providerTokens,
@@ -188,4 +195,3 @@ export async function getVercelAITools(
 
   return vercelTools;
 }
-

--- a/src/code-mode/executor.ts
+++ b/src/code-mode/executor.ts
@@ -48,10 +48,29 @@ interface SandboxFactory {
  * forcing the real package to be installed.
  */
 let sandboxFactoryOverride: SandboxFactory | null = null;
+let _sandboxAvailableCache: boolean | null = null;
 
 /** @internal — used by unit tests to stub the sandbox SDK. */
 export function __setSandboxFactoryForTests(factory: SandboxFactory | null): void {
   sandboxFactoryOverride = factory;
+  _sandboxAvailableCache = null;
+}
+
+export async function isSandboxAvailable(): Promise<boolean> {
+  if (_sandboxAvailableCache !== null) return _sandboxAvailableCache;
+  if (sandboxFactoryOverride) {
+    _sandboxAvailableCache = true;
+    return true;
+  }
+  try {
+    const dynamicImport = new Function("specifier", "return import(specifier)") as (s: string) => Promise<any>;
+    await dynamicImport("@" + "vercel/sandbox");
+    _sandboxAvailableCache = true;
+    return true;
+  } catch {
+    _sandboxAvailableCache = false;
+    return false;
+  }
 }
 
 async function loadSandboxFactory(): Promise<SandboxFactory> {

--- a/src/code-mode/index.ts
+++ b/src/code-mode/index.ts
@@ -22,6 +22,7 @@ export { RUNTIME_STUB_SOURCE } from "./runtime-stub.js";
 
 export {
   buildCodeModeTool,
+  canUseCodeMode,
   CODE_MODE_TOOL_NAME,
   type CodeModeToolOptions,
   type CodeModeToolDefinition,

--- a/src/code-mode/tool-builder.ts
+++ b/src/code-mode/tool-builder.ts
@@ -12,7 +12,11 @@ import type { MCPClient } from "../client.js";
 import type { MCPContext } from "../config/types.js";
 import type { MCPTool } from "../protocol/messages.js";
 import { generateCodeModeTypes } from "./type-generator.js";
-import { executeSandboxCode, type ExecuteSandboxCodeResult } from "./executor.js";
+import {
+  executeSandboxCode,
+  isSandboxAvailable,
+  type ExecuteSandboxCodeResult,
+} from "./executor.js";
 import { getEnv } from "../utils/env.js";
 
 export const CODE_MODE_TOOL_NAME = "execute_code";
@@ -87,6 +91,13 @@ export function resolveCodeModeClientConfig(client: MCPClient<any>): {
 } {
   const oauthConfig = (client as any).__oauthConfig;
   return (oauthConfig?.codeMode ?? {}) as Record<string, any>;
+}
+
+export async function canUseCodeMode(client: MCPClient<any>): Promise<boolean> {
+  if (!(await isSandboxAvailable())) return false;
+  const serverConfig = resolveCodeModeClientConfig(client);
+  const publicUrl = serverConfig.publicUrl ?? getEnv("INTEGRATE_PUBLIC_URL");
+  return !!publicUrl;
 }
 
 /**

--- a/tests/ai/code-mode-defaults.test.ts
+++ b/tests/ai/code-mode-defaults.test.ts
@@ -1,0 +1,141 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { createMCPClient } from "../../src/client.js";
+import { createSimpleIntegration } from "../../src/integrations/generic.js";
+import { getVercelAITools } from "../../src/ai/vercel-ai.js";
+import { getOpenAITools } from "../../src/ai/openai.js";
+import { getAnthropicTools } from "../../src/ai/anthropic.js";
+import { getGoogleTools } from "../../src/ai/google.js";
+import { CODE_MODE_TOOL_NAME } from "../../src/code-mode/tool-builder.js";
+import { __setSandboxFactoryForTests } from "../../src/code-mode/executor.js";
+import type { MCPTool } from "../../src/protocol/messages.js";
+
+const MOCK_TOOL: MCPTool = {
+  name: "test_tool",
+  description: "Test tool",
+  inputSchema: {
+    type: "object",
+    properties: {
+      input: {
+        type: "string",
+      },
+    },
+    required: ["input"],
+  },
+};
+
+function createTestClient(publicUrl?: string) {
+  const client = createMCPClient({
+    integrations: [
+      createSimpleIntegration({
+        id: "test",
+        tools: [MOCK_TOOL.name],
+      }),
+    ],
+  });
+
+  (client as any).availableTools = new Map([[MOCK_TOOL.name, MOCK_TOOL]]);
+  (client as any).initialized = true;
+  (client as any).transport = { isConnected: () => true };
+  (client as any).__oauthConfig = {
+    integrations: [{ id: "test" }],
+    codeMode: publicUrl ? { publicUrl } : undefined,
+  };
+
+  return client;
+}
+
+function makeSandboxFactory() {
+  return {
+    async create() {
+      return {
+        async writeFiles() {},
+        async runCommand() {
+          return {
+            exitCode: 0,
+            stdout: async () => "",
+            stderr: async () => "",
+          };
+        },
+        async stop() {},
+      };
+    },
+  } as any;
+}
+
+afterEach(() => {
+  __setSandboxFactoryForTests(null);
+  delete process.env.INTEGRATE_PUBLIC_URL;
+});
+
+describe("AI helper code mode defaults", () => {
+  test("falls back to tools mode for all helpers when sandbox is unavailable", async () => {
+    const client = createTestClient();
+
+    const [vercelTools, openaiTools, anthropicTools, googleTools] = await Promise.all([
+      getVercelAITools(client),
+      getOpenAITools(client),
+      getAnthropicTools(client),
+      getGoogleTools(client),
+    ]);
+
+    expect(Object.keys(vercelTools)).toEqual(["test_tool"]);
+    expect(openaiTools.map((tool) => tool.name)).toEqual(["test_tool"]);
+    expect(anthropicTools.map((tool) => tool.name)).toEqual(["test_tool"]);
+    expect(googleTools.map((tool) => tool.name)).toEqual(["test_tool"]);
+  });
+
+  test("falls back to tools mode for all helpers when publicUrl is unavailable", async () => {
+    __setSandboxFactoryForTests(makeSandboxFactory());
+    const client = createTestClient();
+
+    const [vercelTools, openaiTools, anthropicTools, googleTools] = await Promise.all([
+      getVercelAITools(client),
+      getOpenAITools(client),
+      getAnthropicTools(client),
+      getGoogleTools(client),
+    ]);
+
+    expect(vercelTools[CODE_MODE_TOOL_NAME]).toBeUndefined();
+    expect(openaiTools.some((tool) => tool.name === CODE_MODE_TOOL_NAME)).toBe(false);
+    expect(anthropicTools.some((tool) => tool.name === CODE_MODE_TOOL_NAME)).toBe(false);
+    expect(googleTools.some((tool) => tool.name === CODE_MODE_TOOL_NAME)).toBe(false);
+  });
+
+  test("defaults to code mode for all helpers when sandbox and publicUrl are available", async () => {
+    __setSandboxFactoryForTests(makeSandboxFactory());
+    const client = createTestClient("https://example.com");
+
+    const [vercelTools, openaiTools, anthropicTools, googleTools] = await Promise.all([
+      getVercelAITools(client),
+      getOpenAITools(client),
+      getAnthropicTools(client),
+      getGoogleTools(client),
+    ]);
+
+    expect(Object.keys(vercelTools)).toContain(CODE_MODE_TOOL_NAME);
+    expect(openaiTools.some((tool) => tool.name === CODE_MODE_TOOL_NAME)).toBe(true);
+    expect(anthropicTools.some((tool) => tool.name === CODE_MODE_TOOL_NAME)).toBe(true);
+    expect(googleTools.some((tool) => tool.name === CODE_MODE_TOOL_NAME)).toBe(true);
+  });
+
+  test("uses INTEGRATE_PUBLIC_URL env var when auto-detecting code mode", async () => {
+    __setSandboxFactoryForTests(makeSandboxFactory());
+    process.env.INTEGRATE_PUBLIC_URL = "https://example.com";
+    const client = createTestClient();
+
+    const openaiTools = await getOpenAITools(client);
+
+    expect(openaiTools.some((tool) => tool.name === CODE_MODE_TOOL_NAME)).toBe(true);
+  });
+
+  test("preserves explicit code mode when sandbox is unavailable", async () => {
+    const client = createTestClient("https://example.com");
+
+    const vercelTools = await getVercelAITools(client, { mode: "code" });
+    const result = await vercelTools[CODE_MODE_TOOL_NAME].execute({ code: "return 1;" });
+
+    expect(vercelTools[CODE_MODE_TOOL_NAME]).toBeDefined();
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Code Mode requires the optional peer dependency `@vercel/sandbox`.");
+  });
+});

--- a/tests/code-mode/executor.test.ts
+++ b/tests/code-mode/executor.test.ts
@@ -9,6 +9,7 @@ import { describe, test, expect, afterEach } from "bun:test";
 import {
   executeSandboxCode,
   __setSandboxFactoryForTests,
+  isSandboxAvailable,
 } from "../../src/code-mode/executor.js";
 
 interface RecordedCommand {
@@ -65,6 +66,29 @@ function makeFakeSandbox(opts: {
 describe("executeSandboxCode", () => {
   afterEach(() => {
     __setSandboxFactoryForTests(null);
+  });
+
+  test("reports sandbox as available when a test factory override is set", async () => {
+    __setSandboxFactoryForTests(makeFakeSandbox());
+
+    await expect(isSandboxAvailable()).resolves.toBe(true);
+  });
+
+  test("reports sandbox as unavailable when no override is set", async () => {
+    __setSandboxFactoryForTests(null);
+
+    await expect(isSandboxAvailable()).resolves.toBe(false);
+  });
+
+  test("resets the sandbox availability cache when the test override changes", async () => {
+    __setSandboxFactoryForTests(null);
+    await expect(isSandboxAvailable()).resolves.toBe(false);
+
+    __setSandboxFactoryForTests(makeFakeSandbox());
+    await expect(isSandboxAvailable()).resolves.toBe(true);
+
+    __setSandboxFactoryForTests(null);
+    await expect(isSandboxAvailable()).resolves.toBe(false);
   });
 
   test("writes runtime stub + wrapped user code and runs node user.mjs", async () => {


### PR DESCRIPTION
This PR auto-detects Code Mode availability and falls back silently to tools mode when `@vercel/sandbox` is not installed or `publicUrl` is not configured, while preserving explicit mode choices.

**Code-mode executor (`src/code-mode/executor.ts`)**
- Added `isSandboxAvailable()` that dynamically imports `@vercel/sandbox` and caches the result
- Reset `_sandboxAvailableCache` in `__setSandboxFactoryForTests` so test isolation works correctly

**Code-mode builder (`src/code-mode/tool-builder.ts`)**
- Added `canUseCodeMode(client)` that checks both sandbox availability and `publicUrl` from config or `INTEGRATE_PUBLIC_URL`

**Exports (`src/code-mode/index.ts`)**
- Exported `canUseCodeMode` from the code-mode public surface

**AI helpers (`src/ai/vercel-ai.ts`, `openai.ts`, `anthropic.ts`, `google.ts`)**
- Replaced `const mode = options?.mode ?? 'code'` with async auto-detect: effective mode is explicit `options.mode` when set, otherwise calls `canUseCodeMode(client)` to choose between `'code'` and `'tools'`
- Updated JSDoc to clarify the new default behavior

**Tests (`tests/code-mode/executor.test.ts`, `tests/ai/code-mode-defaults.test.ts`)**
- Added executor tests for `isSandboxAvailable()` with factory override and cache-reset scenarios
- Added helper tests validating all four helpers fall back to tools mode when sandbox or publicUrl missing, default to code mode when both present, respect `INTEGRATE_PUBLIC_URL`, and preserve explicit `mode: 'code'` with existing runtime error behavior

<a href="https://capy.ai/project/6c90eba2-65fe-4739-b912-02a89584e545/pull/64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/6c90eba2-65fe-4739-b912-02a89584e545/task/b91910f4-d59f-4cfd-b56b-262209990c97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=REPO-1&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=REPO-1"><img alt="REPO-1 · 5.4" src="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=REPO-1"></picture></a>