### PR TITLE
feat: load provider tokens from PROVIDER_TOKENS env

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,6 @@
 {
   "name": "integrate-sdk",
-<<<<<<< HEAD
-  "version": "0.9.15",
-=======
-  "version": "0.9.1",
->>>>>>> 9af3ea2 (Load provider tokens from PROVIDER_TOKENS environment variable)
+  "version": "0.9.16",
   "description": "Type-safe 3rd party integration SDK for the Integrate MCP server",
   "type": "module",
   "main": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "integrate-sdk",
+<<<<<<< HEAD
   "version": "0.9.15",
+=======
+  "version": "0.9.1",
+>>>>>>> 9af3ea2 (Load provider tokens from PROVIDER_TOKENS environment variable)
   "description": "Type-safe 3rd party integration SDK for the Integrate MCP server",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/client.ts
+++ b/src/client.ts
@@ -403,6 +403,13 @@ export class MCPClientBase<TIntegrations extends readonly MCPIntegration[] = rea
         logger.error('Failed to load provider tokens:', error);
       });
     } else {
+      // Auto-load tokens from PROVIDER_TOKENS env var for sandbox/code execution environments.
+      // This enables user integrations to work when tokens are injected via environment variables
+      // (e.g. when code runs in a Vercel sandbox for code mode). Must happen before
+      // loadAllProviderTokensSync so the auth-state update below picks up env var tokens.
+      // Only applies when no database callbacks are configured (callbacks take precedence).
+      this.oauthManager.loadTokensFromEnvVar();
+
       // IndexedDB: Load tokens asynchronously (IndexedDB operations are async)
       // Always load existing tokens first, even if there's an OAuth callback pending
       // This ensures any previously saved tokens are available immediately
@@ -2263,4 +2270,3 @@ export async function clearClientCache(): Promise<void> {
     })
   );
 }
-

--- a/src/oauth/manager.ts
+++ b/src/oauth/manager.ts
@@ -883,6 +883,44 @@ export class OAuthManager {
   }
 
   /**
+   * Load provider tokens from the PROVIDER_TOKENS environment variable.
+   *
+   * In sandbox/code-execution environments (e.g. Vercel sandbox for code mode),
+   * the host passes user OAuth tokens via this env var because there is no browser
+   * storage or database callback available. Tokens are loaded into the in-memory
+   * cache only — they are never persisted.
+   *
+   * Format: JSON object mapping provider name → access token string.
+   * Example: PROVIDER_TOKENS='{"github":"ghp_...","gmail":"ya29...."}'
+   */
+  loadTokensFromEnvVar(): void {
+    try {
+      if (typeof process === 'undefined' || !process.env?.PROVIDER_TOKENS) {
+        return;
+      }
+
+      const parsed = JSON.parse(process.env.PROVIDER_TOKENS) as Record<string, unknown>;
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        logger.warn('PROVIDER_TOKENS env var is set but is not a JSON object — skipping');
+        return;
+      }
+
+      for (const [provider, token] of Object.entries(parsed)) {
+        if (typeof token === 'string') {
+          this.providerTokens.set(provider, {
+            accessToken: token,
+            tokenType: 'Bearer',
+            expiresIn: 0,
+          });
+          logger.debug(`Loaded token for ${provider} from PROVIDER_TOKENS env var`);
+        }
+      }
+    } catch {
+      // Ignore — PROVIDER_TOKENS may not be set or may be invalid JSON
+    }
+  }
+
+  /**
    * Save pending auth to localStorage (for redirect flows)
    * Uses localStorage instead of sessionStorage because OAuth may open in a new tab,
    * and sessionStorage is isolated per tab. localStorage is shared across tabs.
@@ -1111,4 +1149,3 @@ export class OAuthManager {
     this.windowManager.close();
   }
 }
-


### PR DESCRIPTION
This PR adds token loading from the PROVIDER_TOKENS environment variable to enable OAuth in sandbox/code-execution environments where database callbacks and browser storage are unavailable.

- Adds `OAuthManager.loadTokensFromEnvVar()` in `src/oauth/manager.ts` that parses PROVIDER_TOKENS JSON, validates it, and hydrates the in-memory cache
- Calls `loadTokensFromEnvVar()` in `src/client.ts` constructor's non-database-callback branch before `loadAllProviderTokensSync` so env var tokens are picked up by auth-state update
- Bumps version to 0.9.1 in `package.json`

<a href="https://capy.ai/project/9b78d197-049f-401a-bf80-ebead915bcd7/pull/68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/9b78d197-049f-401a-bf80-ebead915bcd7/task/9237f96b-efb2-4cdc-baca-7e7cb51a04da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=INTE-1&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=INTE-1"><img alt="INTE-1 · 5.4" src="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=INTE-1"></picture></a>